### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 bower install code-highlighter
 ```
 
-Or would you prefer a cdn: `//cdn.jsdelivr.net/code-highlighter/2.2.0/code-highlighter.min.js`
+Or would you prefer a cdn: `//cdn.jsdelivr.net/gh/avielfedida/Code-Highlighter@2.2.0/code-highlighter.min.js`
 
 ## Usage
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/avielfedida/Code-Highlighter.

Feel free to ping me if you have any questions regarding this change.